### PR TITLE
docs(discord): fix right server link

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,7 +199,7 @@
       </a>
       <a
         class="button is-medium is-discord"
-        href="https://discord.com/channels/1344433118924374148/1344433119549329532"
+        href="https://discord.gg/NjKZERK95Y"
       >
         <span class="icon">
           <i class="fab fa-discord fa-lg"></i>


### PR DESCRIPTION
# Pull Request: Update Discord Link to Official Server

This pull request updates the website to use the correct link to the official Discord server, following the change made in https://github.com/freelensapp/freelens/pull/747.

**Summary of changes:**

* Updated the Discord link on the website to point to the official server.

**Context:**

* Ensures consistency across the ecosystem by using the correct Discord invite URL, matching the update made in the main repository.